### PR TITLE
Use public HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.1",
   "description": "An implementation of a Gaussian Mixture class in one dimension, that allows to fit models with an Expectation Maximization algorithm.",
   "main": "index.js",
-  "repository": "git@github.com:benjamintd/gaussian-mixture.git",
+  "repository": "git+https://github.com/benjamintd/gaussian-mixture.git",
   "scripts": {
     "test": "npm run lint && tap test/*.test.js",
     "lint": "eslint '*.js' 'test/*.test.js'",


### PR DESCRIPTION
This updates the npm package repository metadata to use a public HTTPS Git URL instead of the current SSH/SCP-style URL.

Current value:

```json
repository: git@github.com:benjamintd/gaussian-mixture.git
```

Updated value:

```json
repository: git+https://github.com/benjamintd/gaussian-mixture.git
```

This is a metadata-only change:
- no runtime code changes
- no dependency changes
- no version or entrypoint changes

Validation:
- confirmed the current `package.json` fails an assertion expecting the public HTTPS repository URL
- confirmed this branch passes the same assertion
- confirmed the compare contains one commit and only changes `package.json`